### PR TITLE
Utilization of required-only functions from lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "node": ">=4"
   },
   "dependencies": {
-    "lodash": "^4.17.4",
+    "lodash.isnumber": "^3.0.3",
+    "lodash.isobject": "^3.0.2",
+    "lodash.isstring": "^4.0.1",
     "make-error": "^1.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "node": ">=4"
   },
   "dependencies": {
-    "lodash.isnumber": "^3.0.3",
-    "lodash.isobject": "^3.0.2",
-    "lodash.isstring": "^4.0.1",
     "make-error": "^1.3.0"
   },
   "devDependencies": {

--- a/src/parse.js
+++ b/src/parse.js
@@ -2,9 +2,12 @@
 
 // ===================================================================
 
-import isNumber from 'lodash.isnumber'
-import isString from 'lodash.isstring'
-import isObject from 'lodash.isobject'
+import {
+  isNumber,
+  isInteger,
+  isString,
+  isObject
+} from './types'
 
 import {
   InvalidJson,
@@ -12,8 +15,6 @@ import {
 } from './errors'
 
 // ===================================================================
-
-const isInteger = value => isNumber(value) && (value % 1 === 0)
 
 const { defineProperty } = Object
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -2,11 +2,9 @@
 
 // ===================================================================
 
-import isArray from 'lodash/isArray'
-import isNumber from 'lodash/isNumber'
-import isObject from 'lodash/isObject'
-import isString from 'lodash/isString'
-import map from 'lodash/map'
+import isNumber from 'lodash.isnumber'
+import isString from 'lodash.isstring'
+import isObject from 'lodash.isobject'
 
 import {
   InvalidJson,
@@ -60,7 +58,7 @@ const checkParams = (params, version) => {
   if (version === '2.0') {
     if (
       params !== undefined &&
-      !isArray(params) &&
+      !Array.isArray(params) &&
       !isObject(params)
     ) {
       throw new InvalidRequest(
@@ -68,7 +66,7 @@ const checkParams = (params, version) => {
       )
     }
   } else {
-    if (!isArray(params)) {
+    if (!Array.isArray(params)) {
       throw new InvalidRequest(
         `invalid params: ${getType(params)} instead of array`
       )
@@ -120,8 +118,8 @@ export default function parse (message) {
   }
 
   // Properly handle array of requests.
-  if (isArray(message)) {
-    return map(message, message => parse(message))
+  if (Array.isArray(message)) {
+    return message.map(parse)
   }
 
   const version = detectJsonRpcVersion(message)

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,24 @@
+const negativeInf = Number.NEGATIVE_INFINITY
+const positiveInf = Number.POSITIVE_INFINITY
+
+// ===================================================================
+
+export const isNumber = value => {
+  return typeof value === 'number' && value > negativeInf && value < positiveInf
+}
+
+// -------------------------------------------------------------------
+
+export const isInteger = value => isNumber(value) && (value % 1 === 0)
+
+// -------------------------------------------------------------------
+
+export const isString = value => typeof value === 'string'
+
+// -------------------------------------------------------------------
+
+export const isObject = value => {
+  const type = typeof value
+
+  return value !== null && (type === 'object' || type === 'function')
+}

--- a/src/types.js
+++ b/src/types.js
@@ -4,7 +4,9 @@ const positiveInf = Number.POSITIVE_INFINITY
 // ===================================================================
 
 export const isNumber = value => {
-  return typeof value === 'number' && value > negativeInf && value < positiveInf
+  const type = typeof value
+
+  return type === 'number' && value > negativeInf && value < positiveInf
 }
 
 // -------------------------------------------------------------------

--- a/src/types.spec.js
+++ b/src/types.spec.js
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+
+import {
+  isNumber,
+  isInteger,
+  isString,
+  isObject
+} from './types'
+
+// ===================================================================
+
+describe('types', () => {
+  describe('isNumber()', () => {
+    it('true on numbers', () => {
+      expect(isNumber(1)).toBe(true)
+      expect(isNumber(0)).toBe(true)
+      expect(isNumber(-1)).toBe(true)
+      expect(isNumber(1.1)).toBe(true)
+    })
+    it('false on non-numbers', () => {
+      expect(isNumber(null)).toBe(false)
+      expect(isNumber('1')).toBe(false)
+      expect(isNumber('a')).toBe(false)
+      expect(isNumber({})).toBe(false)
+      expect(isNumber([])).toBe(false)
+    })
+    it('false on Infinity', () => {
+      expect(isNumber(Infinity)).toBe(false)
+    })
+  })
+
+  describe('isInteger()', () => {
+    it('true on integers', () => {
+      expect(isInteger(1)).toBe(true)
+      expect(isInteger(0)).toBe(true)
+      expect(isInteger(-1)).toBe(true)
+    })
+    it('false on non-integers', () => {
+      expect(isObject(null)).toBe(false)
+      expect(isInteger(1.1)).toBe(false)
+      expect(isInteger('1')).toBe(false)
+    })
+  })
+
+  describe('isString()', () => {
+    it('true on strings', () => {
+      expect(isString('')).toBe(true)
+      expect(isString('a')).toBe(true)
+      expect(isString('1')).toBe(true)
+      expect(isString('test')).toBe(true)
+    })
+    it('false on non-strings', () => {
+      expect(isString(null)).toBe(false)
+      expect(isString(1)).toBe(false)
+      expect(isString({})).toBe(false)
+      expect(isString([])).toBe(false)
+    })
+  })
+
+  describe('isObject()', () => {
+    it('true on objects', () => {
+      expect(isObject({})).toBe(true)
+      expect(isObject({ a: 1 })).toBe(true)
+      expect(isObject([])).toBe(true)
+      expect(isObject(Function)).toBe(true)
+    })
+    it('false on non-objects', () => {
+      expect(isObject(null)).toBe(false)
+      expect(isObject(1)).toBe(false)
+      expect(isObject(1.1)).toBe(false)
+      expect(isObject('a')).toBe(false)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2452,18 +2452,6 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.isnumber@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-
-lodash.isstring@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
-
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2452,7 +2452,19 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Great package overall, the only thing that bugs me on the current project is utilization of `lodash` package - only couple of methods are in use, with `isArray` marked as deprecated and `map` seeming redundant; and while `lodash` is very modular, the whole package gets installed.

This PR does the following:

1. Instead of whole `lodash` package, only spare function are installed;
2. Deprecated `lodash.isArray` exchanged in favor of native `Array.isArray`;
3. `lodash.map` exchanged for native `Array.map` - no difference in this sense.

As a result, the prod build size is greatly reduced, being:
```
$ du -sh node_modules/
5,1M    node_modules
```
And becoming:
```
$ du -sh node_modules/
188K    node_modules
```

Overall seems like not a big deal, but IMHO a worthy improvement.