### PR TITLE
fix(JsonRpcError): data can be of any type

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,7 +10,7 @@ export class JsonRpcError extends BaseError {
   constructor (
     message = 'unknown error from the peer',
     code = -32000,
-    data?: string
+    data?: any
   ) {
     super(message)
 

--- a/src/json-rpc.type.ts
+++ b/src/json-rpc.type.ts
@@ -55,7 +55,7 @@ export type PayloadType =
 // <-- {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null}
 export interface JsonRpcErrorSchema {
   code: number
-  data?: string
+  data?: any
   message: string
 }
 


### PR DESCRIPTION
It would be great if the `data` property would accept any. For example:

```typescript
throw new InvalidParameters([{
    field: 'name',
    message: 'name property is required',
}]);
```